### PR TITLE
Fix a race condition in SymbolPool.Get

### DIFF
--- a/Core/Loyc.Essentials/Utilities/Symbol.cs
+++ b/Core/Loyc.Essentials/Utilities/Symbol.cs
@@ -268,6 +268,12 @@ namespace Loyc
 		{
 			if ((sym = GetIfExists(name)) == null && name != null)
 				lock (_map) {
+					if ((sym = GetIfExists(name)) != null)
+						// It is possible for another thread to have added 'name' to
+						// '_map' while we were waiting to acquire the lock.
+						// If that has happened, then we want to return now.
+						return;
+
 					if (_idMap != null)
 						while (_idMap.ContainsKey(_nextId))
 							_nextId++;

--- a/Core/Tests/Essentials/SymbolTests.cs
+++ b/Core/Tests/Essentials/SymbolTests.cs
@@ -107,5 +107,27 @@ namespace Loyc
 			Assert.AreEqual(GSymbol.GetById(876543210), null);
 			Assert.AreEqual(GSymbol.GetById(-876543210), null);
 		}
+
+		private static void RunParallel(int parallelCount, Action action)
+		{
+			System.Threading.Tasks.Parallel.Invoke(
+				Enumerable.Repeat(action, parallelCount).ToArray());
+		}
+
+		[Test]
+		public void SymbolGetRaceCondition()
+		{
+			RunParallel(8, () =>
+			{
+				// This test runs eight actions in parallel,
+				// to uncover a possible race condition
+				// in GSymbol.Get
+				const int maxCount = 1000;
+				for (int i = 0; i < maxCount; i++)
+				{
+					GSymbol.Get(i.ToString());
+				}
+			});
+		}
 	}
 }

--- a/Core/Tests/Essentials/SymbolTests.cs
+++ b/Core/Tests/Essentials/SymbolTests.cs
@@ -108,6 +108,7 @@ namespace Loyc
 			Assert.AreEqual(GSymbol.GetById(-876543210), null);
 		}
 
+#if !DotNet35
 		private static void RunParallel(int parallelCount, Action action)
 		{
 			System.Threading.Tasks.Parallel.Invoke(
@@ -115,19 +116,18 @@ namespace Loyc
 		}
 
 		[Test]
-		public void SymbolGetRaceCondition()
+		public void BugFixOct2016_SymbolGetRaceCondition()
 		{
+			// Bug: SymbolPool.Get used to check the symbol table contained the symbol's 
+			// name, and then acquire a lock if it didn't. Inside the lock it assumed that _map 
+			// would still not contain the symbol and called Add(), which threw 
+			// KeyAlreadyExistsException when the assumption was false.
 			RunParallel(8, () =>
 			{
-				// This test runs eight actions in parallel,
-				// to uncover a possible race condition
-				// in GSymbol.Get
-				const int maxCount = 1000;
-				for (int i = 0; i < maxCount; i++)
-				{
+				for (int i = 0; i < 1000; i++)
 					GSymbol.Get(i.ToString());
-				}
 			});
 		}
+#endif
 	}
 }


### PR DESCRIPTION
Hi!

I discovered a tiny race condition in `SymbolPool.Get(string, out Symbol)`, which was hurting `ecsc`'s ability to parse and macro-expand multiple EC# source code files in parallel (I actually had to switch back to sequential mode). This (small) pull request fixes said race condition, and adds a test case to verify. I've taken the liberty of including a reformatted version of the commit message below, to explain what went wrong and why my suggested fix tackles the issue in the way it does. 

> `SymbolPool.Get` used to check if `_map` contained the symbol's name, and then acquire a `lock` if that was not the case. Once inside the `lock`, the algorithm assumed that `_map` would still not contain the symbol. But it didn't account for the possibility that another thread could insert the symbol into `_map` in while the current thread was waiting for the `lock`. 
> This sometimes resulted in an exception.

> An extra check has been inserted in the `lock` statement to check that the assumption still holds before inserting a symbol in the map. It would have been simpler to move the initial check inside the `lock` statement, but that would penalize the hot path.

Does this look okay to you?